### PR TITLE
fix: resolve intermittent pageload flicker with `hideImageLayer` set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visionary-image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./dist/visionary-image.umd.js",
   "module": "./dist/visionary-image.es.js",

--- a/src/components/Image/Image.module.scss
+++ b/src/components/Image/Image.module.scss
@@ -7,10 +7,6 @@
   }
 }
 
-.hidden {
-  display: none;
-}
-
 .preventDrag {
   -webkit-user-drag: none;
   pointer-events: none;

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -13,7 +13,7 @@ import { BG_ALPHA, BLURHASH_PUNCH, CANVAS_SIZE } from "../../lib/constants";
 import { useIsomorphicLayoutEffect } from "../../lib/hook";
 import { logDebug } from "../../lib/logger";
 import { computeImageState } from "../../lib/state";
-import { canvasElementStyles, imageStyles } from "../../lib/styles";
+import { canvasElementStyles, getImageStyles } from "../../lib/styles";
 import { TEST_IDS } from "../../lib/test";
 import { getDebugIdProp, getTestIdProp, round } from "../../lib/util";
 
@@ -30,7 +30,7 @@ export const Image = ({
   disableImageLayer = false,
   endpoint,
   height: userHeight,
-  hideImageLayer,
+  hideImageLayer = false,
   lazy = true,
   onClick,
   onError,
@@ -156,10 +156,7 @@ export const Image = ({
   const containerProps: DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> = {
     onClick,
   };
-  const imageClasses = classnames({
-    [styles.hidden]: !!hideImageLayer,
-  });
-
+  const imageStyles = getImageStyles(hideImageLayer);
   return (
     <div
       className={containerClasses}
@@ -184,7 +181,6 @@ export const Image = ({
         <img
           {...sharedImgProps}
           {...getTestIdProp(TEST_IDS.IMAGE)}
-          className={imageClasses}
           onError={handleImageError}
           src={imageState.src}
           style={imageStyles}

--- a/src/components/Image/__test__/Image.test.tsx
+++ b/src/components/Image/__test__/Image.test.tsx
@@ -36,8 +36,10 @@ describe("Image component", () => {
     expect(imageElement).toBeInstanceOf(HTMLImageElement);
     expect(imageElement).toHaveProperty("src");
     expect(imageElement).toHaveProperty("className");
-    expect(imageElement?.className).not.toContain("hidden");
     expect(imageElement.getAttribute("alt")).toEqual(altText);
+
+    const imageStyles = window.getComputedStyle(imageElement);
+    expect(imageStyles.display).not.toBe("none");
   });
 
   test("renders with blur disabled", () => {
@@ -50,7 +52,9 @@ describe("Image component", () => {
 
     const imageElement = screen.queryByTestId(TEST_IDS.IMAGE);
     expect(imageElement).toBeInstanceOf(HTMLImageElement);
-    expect(imageElement?.className).not.toContain("hidden");
+
+    const imageStyles = window.getComputedStyle(imageElement!);
+    expect(imageStyles.display).not.toBe("none");
   });
 
   test("renders with image disabled", () => {
@@ -75,7 +79,9 @@ describe("Image component", () => {
 
     const imageElement = screen.queryByTestId(TEST_IDS.IMAGE);
     expect(imageElement).toBeInstanceOf(HTMLImageElement);
-    expect(imageElement?.className).toContain("hidden");
+
+    const imageStyles = window.getComputedStyle(imageElement!);
+    expect(imageStyles.display).toBe("none");
   });
 
   // src as a Visionary code (not URL)

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -9,7 +9,7 @@ const absoluteCoverStyles: CSSProperties = {
 };
 
 /** We apply CSS on the image directly via the `style` prop, as a delay in .css file loading can cause a FOUC. */
-export const imageStyles: CSSProperties = {
+export const baseImageStyles: CSSProperties = {
   ...absoluteCoverStyles,
   maxHeight: "100%",
   maxWidth: "100%",
@@ -19,4 +19,14 @@ export const canvasElementStyles: CSSProperties = {
   ...absoluteCoverStyles,
   height: "100%",
   width: "100%",
+};
+
+export const getImageStyles = (hideImageLayer: boolean): CSSProperties => {
+  const styles: CSSProperties = {
+    ...baseImageStyles,
+  };
+  if (hideImageLayer) {
+    styles.display = "none";
+  }
+  return styles;
 };


### PR DESCRIPTION
Prevent flash of visibility when DOM is ready before CSS loads and `hideImageLayer` is true.

- Apply hidden style via inline styles for immediate effect