### PR TITLE
publish `v1.1.0`

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -60,7 +60,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm run types:validate
+      - name: Select npm dist-tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$PKG_VERSION" == *-* ]]; then
+            echo "NPM_DIST_TAG=next" >> "$GITHUB_ENV"
+          else
+            echo "NPM_DIST_TAG=latest" >> "$GITHUB_ENV"
+          fi
       - name: Publish dry-run
-        run: npm publish --dry-run --tag next
+        run: npm publish --dry-run --tag "$NPM_DIST_TAG"
       - name: Publish to npm
-        run: npm publish --tag next
+        run: npm publish --tag "$NPM_DIST_TAG"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "visionary-image",
   "description": "Visionary Image — The easiest way to Blurhash. Renders true-to-size placeholders that eliminate layout shift and crush Core Web Vitals. SSR-ready React & Web Components.",
-  "version": "1.1.0-pre.0",
+  "version": "1.1.0",
   "homepage": "https://visionary.cloud",
   "type": "module",
   "main": "./dist/visionary-image.cjs",


### PR DESCRIPTION
- publish `v1.1.0`
- auto tag npm release with `latest` or `next` depending on package version